### PR TITLE
Integrate Supabase-backed storage for reports and routes

### DIFF
--- a/lib/services/safe_route_local_data_source.dart
+++ b/lib/services/safe_route_local_data_source.dart
@@ -1,11 +1,11 @@
 import '../models/safe_route.dart';
-import 'local_storage_service.dart';
+import 'storage_service.dart';
 
 class SafeRouteLocalDataSource {
-  SafeRouteLocalDataSource({LocalStorageService? storage})
-      : _storage = storage ?? LocalStorageService.instance;
+  SafeRouteLocalDataSource({StorageService? storage})
+      : _storage = storage ?? StorageService.instance;
 
-  final LocalStorageService _storage;
+  final StorageService _storage;
 
   Future<List<SafeRoute>> loadRoutes() => _storage.loadSafeRoutes();
 


### PR DESCRIPTION
## Summary
- initialize the shared storage service during app startup to hydrate local caches from Supabase
- refactor the report workflow to use the Supabase-backed repository for syncing reports and preferences with updated status messaging
- convert local persistence into a cache layer and route data source into a Supabase delegate to keep safe routes in sync

## Testing
- not run (Flutter SDK unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68df30f811fc83309a24f4984addfb8e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Cloud synchronization for reports, user preferences, and safe routes.
  - Automatically loads existing routes; applies default routes when none are found.

- Bug Fixes
  - More reliable startup with safe fallbacks to defaults.
  - Prevents UI updates after leaving a page, reducing crashes.
  - Clearer error handling with snackbars when sync or load fails.

- UX
  - Updated copy: “guardados” → “sincronizados” and clarified “en el dispositivo” vs “en la nube” across labels, headers, and messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->