### PR TITLE
Fix local report sync to preserve Supabase identifiers

### DIFF
--- a/lib/services/local_storage_service.dart
+++ b/lib/services/local_storage_service.dart
@@ -109,6 +109,55 @@ class LocalStorageService {
     await _loadStoredReports();
   }
 
+  Future<Report> saveReport({
+    Report? report,
+    ReportType? type,
+    String? description,
+    double? latitude,
+    double? longitude,
+    String? id,
+    DateTime? createdAt,
+  }) async {
+    await _ensureInitialized();
+    final Box<Map<String, dynamic>>? box = _reportsBox;
+    if (box == null) {
+      throw StateError('Reports box is not initialized');
+    }
+
+    Report reportToSave;
+    if (report != null) {
+      reportToSave = report;
+    } else {
+      if (type == null) {
+        throw ArgumentError(
+          'type is required when report is not provided',
+        );
+      }
+      if (description == null) {
+        throw ArgumentError(
+          'description is required when report is not provided',
+        );
+      }
+
+      final String resolvedId = id ??
+          DateTime.now().microsecondsSinceEpoch.toString();
+      final DateTime resolvedCreatedAt = createdAt ?? DateTime.now();
+
+      reportToSave = Report(
+        id: resolvedId,
+        typeId: type.id,
+        description: description,
+        createdAt: resolvedCreatedAt,
+        latitude: latitude,
+        longitude: longitude,
+      );
+    }
+
+    await box.put(reportToSave.id, reportToSave.toJson());
+    await _loadStoredReports();
+    return reportToSave;
+  }
+
   Future<void> cacheReport(Report report) async {
     await _ensureInitialized();
     final Box<Map<String, dynamic>>? box = _reportsBox;

--- a/lib/services/reports_remote_data_source.dart
+++ b/lib/services/reports_remote_data_source.dart
@@ -1,0 +1,24 @@
+import '../models/report.dart';
+import '../models/safe_route.dart';
+import '../models/user_preferences.dart';
+
+abstract class ReportsRemoteDataSource {
+  Future<Report> saveReport({
+    required ReportType type,
+    required String description,
+    double? latitude,
+    double? longitude,
+  });
+
+  Future<List<Report>> getReports();
+
+  Future<void> deleteReport(String id);
+
+  Future<void> saveUserPreferences(UserPreferences preferences);
+
+  Future<UserPreferences?> getUserPreferences();
+
+  Future<void> saveSafeRoutes(List<SafeRoute> routes);
+
+  Future<List<SafeRoute>> getSafeRoutes();
+}

--- a/lib/services/supabase_service.dart
+++ b/lib/services/supabase_service.dart
@@ -5,8 +5,9 @@ import 'package:flutter_dotenv/flutter_dotenv.dart';
 import '../models/report.dart';
 import '../models/safe_route.dart';
 import '../models/user_preferences.dart';
+import 'reports_remote_data_source.dart';
 
-class SupabaseService {
+class SupabaseService implements ReportsRemoteDataSource {
   SupabaseService._();
 
   static final SupabaseService instance = SupabaseService._();

--- a/test/services/storage_service_test.dart
+++ b/test/services/storage_service_test.dart
@@ -1,0 +1,155 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:app_turismo/models/report.dart';
+import 'package:app_turismo/models/safe_route.dart';
+import 'package:app_turismo/models/user_preferences.dart';
+import 'package:app_turismo/services/local_storage_service.dart';
+import 'package:app_turismo/services/reports_remote_data_source.dart';
+import 'package:app_turismo/services/storage_service.dart';
+
+class _FakeSupabaseService implements ReportsRemoteDataSource {
+  _FakeSupabaseService({List<Report>? reports})
+      : _reports = List<Report>.from(reports ?? <Report>[]);
+
+  List<Report> _reports;
+  UserPreferences? _preferences;
+  List<SafeRoute> _routes = <SafeRoute>[];
+
+  void setReports(List<Report> reports) {
+    _reports = List<Report>.from(reports);
+  }
+
+  @override
+  Future<void> deleteReport(String id) async {
+    _reports.removeWhere((Report report) => report.id == id);
+  }
+
+  @override
+  Future<List<Report>> getReports() async {
+    return List<Report>.from(_reports);
+  }
+
+  @override
+  Future<List<SafeRoute>> getSafeRoutes() async {
+    return List<SafeRoute>.from(_routes);
+  }
+
+  @override
+  Future<UserPreferences?> getUserPreferences() async {
+    return _preferences;
+  }
+
+  @override
+  Future<Report> saveReport({
+    required ReportType type,
+    required String description,
+    double? latitude,
+    double? longitude,
+  }) async {
+    final Report report = Report(
+      id: DateTime.now().microsecondsSinceEpoch.toString(),
+      typeId: type.id,
+      description: description,
+      createdAt: DateTime.now(),
+      latitude: latitude,
+      longitude: longitude,
+    );
+    _reports.insert(0, report);
+    return report;
+  }
+
+  @override
+  Future<void> saveSafeRoutes(List<SafeRoute> routes) async {
+    _routes = List<SafeRoute>.from(routes);
+  }
+
+  @override
+  Future<void> saveUserPreferences(UserPreferences preferences) async {
+    _preferences = preferences;
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final LocalStorageService localStorage = LocalStorageService.instance;
+
+  setUpAll(() async {
+    SharedPreferences.setMockInitialValues(<String, Object?>{});
+    await localStorage.initialize();
+  });
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues(<String, Object?>{});
+    await localStorage.clearCachedReports();
+  });
+
+  tearDown(() async {
+    await localStorage.clearCachedReports();
+  });
+
+  test('double synchronization keeps Supabase IDs without duplicating reports', () async {
+    final DateTime createdAt = DateTime(2024, 1, 1, 12);
+    final Report remoteReport = Report(
+      id: 'remote-1',
+      typeId: ReportType.security.id,
+      description: 'Remote description',
+      createdAt: createdAt,
+      latitude: 10.0,
+      longitude: -10.0,
+    );
+
+    final _FakeSupabaseService supabase = _FakeSupabaseService(
+      reports: <Report>[remoteReport],
+    );
+    final StorageService storage = StorageService(
+      localStorage: localStorage,
+      supabase: supabase,
+    );
+
+    await storage.initialize();
+    expect(storage.reports.length, 1);
+    expect(storage.reports.first.id, remoteReport.id);
+
+    await storage.syncReportsFromSupabase();
+
+    expect(storage.reports.length, 1);
+    expect(storage.reports.first.id, remoteReport.id);
+    expect(storage.reports.first.createdAt, createdAt);
+  });
+
+  test('remote deletions are reflected locally without duplicating cached reports', () async {
+    final Report firstReport = Report(
+      id: 'supabase-1',
+      typeId: ReportType.security.id,
+      description: 'First remote report',
+      createdAt: DateTime(2024, 1, 2, 8),
+    );
+    final Report secondReport = Report(
+      id: 'supabase-2',
+      typeId: ReportType.service.id,
+      description: 'Second remote report',
+      createdAt: DateTime(2024, 1, 3, 10),
+    );
+
+    final _FakeSupabaseService supabase = _FakeSupabaseService(
+      reports: <Report>[firstReport, secondReport],
+    );
+    final StorageService storage = StorageService(
+      localStorage: localStorage,
+      supabase: supabase,
+    );
+
+    await storage.initialize();
+    expect(storage.reports.length, 2);
+
+    supabase.setReports(<Report>[secondReport]);
+
+    await storage.syncReportsFromSupabase();
+
+    expect(storage.reports.length, 1);
+    expect(storage.reports.first.id, secondReport.id);
+    expect(storage.reports.first.description, secondReport.description);
+  });
+}


### PR DESCRIPTION
## Summary
- add a reusable remote data source contract and allow `StorageService` to inject dependencies for testing
- persist Supabase provided identifiers when saving reports locally and resync without duplicating cached entries
- cover repeated synchronization and remote deletions with unit tests to ensure the cache respects backend IDs

## Testing
- not run (flutter tool unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68df3378ef848330b742b800d418a7a6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Improved report saving now supports optional location and custom identifiers.
- Bug Fixes
  - Prevents duplicate reports after repeated synchronizations.
  - Remote deletions are correctly reflected locally.
  - More reliable initialization and validation reduce sync errors.
- Refactor
  - Adopted a more flexible storage architecture with an injectable remote data source.
  - Streamlined synchronization for better consistency between local and remote data.
- Tests
  - Added unit tests covering sync reliability, duplicate prevention, and deletion propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->