### PR TITLE
Add Supabase-backed authentication and user-scoped storage

### DIFF
--- a/lib/models/app_user.dart
+++ b/lib/models/app_user.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/foundation.dart';
+
+@immutable
+class AppUser {
+  const AppUser({
+    required this.id,
+    required this.email,
+    this.fullName,
+  });
+
+  final String id;
+  final String email;
+  final String? fullName;
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'id': id,
+      'email': email,
+      'fullName': fullName,
+    };
+  }
+
+  factory AppUser.fromJson(Map<String, dynamic> json) {
+    return AppUser(
+      id: json['id'] as String? ?? '',
+      email: json['email'] as String? ?? '',
+      fullName: json['fullName'] as String?,
+    );
+  }
+
+  AppUser copyWith({
+    String? id,
+    String? email,
+    String? fullName,
+  }) {
+    return AppUser(
+      id: id ?? this.id,
+      email: email ?? this.email,
+      fullName: fullName ?? this.fullName,
+    );
+  }
+}

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -1,0 +1,164 @@
+import 'dart:convert';
+
+import 'package:crypto/crypto.dart';
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import '../models/app_user.dart';
+import 'supabase_service.dart';
+
+class AuthenticationException implements Exception {
+  AuthenticationException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
+class AuthService {
+  AuthService._({
+    SupabaseClient? client,
+  }) : _client = client;
+
+  static final AuthService instance = AuthService._();
+
+  static const String _sessionKey = 'cached_auth_session';
+
+  final SupabaseClient? _client;
+  SharedPreferences? _preferences;
+
+  final ValueNotifier<AppUser?> _currentUserNotifier =
+      ValueNotifier<AppUser?>(null);
+
+  bool _isInitialized = false;
+
+  SupabaseClient get _supabaseClient => _client ?? SupabaseService.instance.client;
+
+  ValueListenable<AppUser?> get currentUserListenable => _currentUserNotifier;
+
+  AppUser? get currentUser => _currentUserNotifier.value;
+
+  bool get isAuthenticated => currentUser != null;
+
+  Future<void> initialize() async {
+    if (_isInitialized) {
+      return;
+    }
+
+    _preferences = await SharedPreferences.getInstance();
+    final String? raw = _preferences?.getString(_sessionKey);
+    if (raw != null && raw.isNotEmpty) {
+      try {
+        final Map<String, dynamic> decoded = Map<String, dynamic>.from(
+          json.decode(raw) as Map<dynamic, dynamic>,
+        );
+        _currentUserNotifier.value = AppUser.fromJson(decoded);
+      } on FormatException {
+        await _preferences?.remove(_sessionKey);
+      } on TypeError {
+        await _preferences?.remove(_sessionKey);
+      }
+    }
+
+    _isInitialized = true;
+  }
+
+  Future<AppUser> login({
+    required String email,
+    required String password,
+  }) async {
+    await _ensureInitialized();
+
+    final String normalizedEmail = email.trim().toLowerCase();
+    final String passwordHash = _hashPassword(password, normalizedEmail);
+
+    final Map<String, dynamic>? response = await _supabaseClient
+        .from('app_users')
+        .select()
+        .eq('email', normalizedEmail)
+        .eq('password_hash', passwordHash)
+        .maybeSingle();
+
+    if (response == null) {
+      throw AuthenticationException('Credenciales inválidas.');
+    }
+
+    final AppUser user = _mapUser(response);
+    await _persistUser(user);
+    return user;
+  }
+
+  Future<AppUser> register({
+    required String email,
+    required String password,
+    String? fullName,
+  }) async {
+    await _ensureInitialized();
+
+    final String normalizedEmail = email.trim().toLowerCase();
+    final String passwordHash = _hashPassword(password, normalizedEmail);
+
+    try {
+      final Map<String, dynamic>? response = await _supabaseClient
+          .from('app_users')
+          .insert(<String, dynamic>{
+            'email': normalizedEmail,
+            'password_hash': passwordHash,
+            'full_name': fullName,
+          })
+          .select()
+          .maybeSingle();
+
+      if (response == null) {
+        throw AuthenticationException('No se pudo completar el registro.');
+      }
+
+      final AppUser user = _mapUser(response);
+      await _persistUser(user);
+      return user;
+    } on PostgrestException catch (error) {
+      if (error.code == '23505') {
+        throw AuthenticationException('El correo ya se encuentra registrado.');
+      }
+      throw AuthenticationException(
+        error.message ?? 'Ocurrió un error al registrar la cuenta.',
+      );
+    }
+  }
+
+  Future<void> logout() async {
+    await _ensureInitialized();
+
+    _currentUserNotifier.value = null;
+    await _preferences?.remove(_sessionKey);
+  }
+
+  Future<void> _persistUser(AppUser user) async {
+    _currentUserNotifier.value = user;
+    await _preferences?.setString(
+      _sessionKey,
+      json.encode(user.toJson()),
+    );
+  }
+
+  AppUser _mapUser(Map<String, dynamic> data) {
+    return AppUser(
+      id: data['id'].toString(),
+      email: (data['email'] as String?)?.toLowerCase() ?? '',
+      fullName: data['full_name'] as String?,
+    );
+  }
+
+  String _hashPassword(String password, String salt) {
+    final List<int> bytes = utf8.encode('$salt::$password');
+    return sha256.convert(bytes).toString();
+  }
+
+  Future<void> _ensureInitialized() async {
+    if (!_isInitialized) {
+      await initialize();
+    }
+  }
+}

--- a/lib/services/reports_remote_data_source.dart
+++ b/lib/services/reports_remote_data_source.dart
@@ -4,21 +4,31 @@ import '../models/user_preferences.dart';
 
 abstract class ReportsRemoteDataSource {
   Future<Report> saveReport({
+    required String userId,
     required ReportType type,
     required String description,
     double? latitude,
     double? longitude,
   });
 
-  Future<List<Report>> getReports();
+  Future<List<Report>> getReports({required String userId});
 
-  Future<void> deleteReport(String id);
+  Future<void> deleteReport({
+    required String id,
+    required String userId,
+  });
 
-  Future<void> saveUserPreferences(UserPreferences preferences);
+  Future<void> saveUserPreferences({
+    required String userId,
+    required UserPreferences preferences,
+  });
 
-  Future<UserPreferences?> getUserPreferences();
+  Future<UserPreferences?> getUserPreferences({required String userId});
 
-  Future<void> saveSafeRoutes(List<SafeRoute> routes);
+  Future<void> saveSafeRoutes({
+    required String userId,
+    required List<SafeRoute> routes,
+  });
 
-  Future<List<SafeRoute>> getSafeRoutes();
+  Future<List<SafeRoute>> getSafeRoutes({required String userId});
 }

--- a/lib/services/storage_service.dart
+++ b/lib/services/storage_service.dart
@@ -19,27 +19,42 @@ class StorageService {
   final LocalStorageService _localStorage;
   final ReportsRemoteDataSource _supabase;
 
-  bool _isInitialized = false;
+  bool _baseInitialized = false;
+  bool _isUserInitialized = false;
+  String? _currentUserId;
 
   Future<void> initialize() async {
-    if (_isInitialized) {
+    if (_baseInitialized) {
       return;
     }
 
     await _localStorage.initialize();
-
-    await Future.wait<void>(<Future<void>>[
-      _syncReportsFromSupabase(),
-      _hydratePreferencesFromSupabase(),
-      _hydrateSafeRoutesFromSupabase(),
-    ]);
-
-    _isInitialized = true;
+    _baseInitialized = true;
   }
 
-  Future<void> _syncReportsFromSupabase() async {
+  Future<void> initializeForUser(String userId) async {
+    await initialize();
+
+    if (_isUserInitialized && _currentUserId == userId) {
+      return;
+    }
+
+    _currentUserId = userId;
+    await _localStorage.configureForUser(userId);
+
+    await Future.wait<void>(<Future<void>>[
+      _syncReportsFromSupabase(userId),
+      _hydratePreferencesFromSupabase(userId),
+      _hydrateSafeRoutesFromSupabase(userId),
+    ]);
+
+    _isUserInitialized = true;
+  }
+
+  Future<void> _syncReportsFromSupabase(String userId) async {
     try {
-      final List<Report> supabaseReports = await _supabase.getReports();
+      final List<Report> supabaseReports =
+          await _supabase.getReports(userId: userId);
       await _localStorage.clearCachedReports();
       for (final Report report in supabaseReports) {
         await _localStorage.saveReport(report: report);
@@ -51,13 +66,15 @@ class StorageService {
 
   @visibleForTesting
   Future<void> syncReportsFromSupabase() async {
-    await _ensureInitialized();
-    await _syncReportsFromSupabase();
+    await _ensureUserInitialized();
+    final String userId = _requiredUserId;
+    await _syncReportsFromSupabase(userId);
   }
 
-  Future<void> _hydratePreferencesFromSupabase() async {
+  Future<void> _hydratePreferencesFromSupabase(String userId) async {
     try {
-      final UserPreferences? preferences = await _supabase.getUserPreferences();
+      final UserPreferences? preferences =
+          await _supabase.getUserPreferences(userId: userId);
       if (preferences != null) {
         await _localStorage.cacheUserPreferences(preferences);
       }
@@ -66,9 +83,10 @@ class StorageService {
     }
   }
 
-  Future<void> _hydrateSafeRoutesFromSupabase() async {
+  Future<void> _hydrateSafeRoutesFromSupabase(String userId) async {
     try {
-      final List<SafeRoute> routes = await _supabase.getSafeRoutes();
+      final List<SafeRoute> routes =
+          await _supabase.getSafeRoutes(userId: userId);
       await _localStorage.cacheSafeRoutes(routes);
     } catch (e) {
       debugPrint('Error al sincronizar rutas seguras desde Supabase: $e');
@@ -85,9 +103,9 @@ class StorageService {
 
   UserPreferences get preferences => _localStorage.preferences;
 
-  Future<void> _ensureInitialized() async {
-    if (!_isInitialized) {
-      await initialize();
+  Future<void> _ensureUserInitialized() async {
+    if (!_isUserInitialized) {
+      throw StateError('No hay un usuario autenticado configurado.');
     }
   }
 
@@ -97,9 +115,12 @@ class StorageService {
     double? latitude,
     double? longitude,
   }) async {
-    await _ensureInitialized();
+    await _ensureUserInitialized();
+
+    final String userId = _requiredUserId;
 
     final Report report = await _supabase.saveReport(
+      userId: userId,
       type: type,
       description: description,
       latitude: latitude,
@@ -111,29 +132,39 @@ class StorageService {
   }
 
   Future<void> deleteReport(String id) async {
-    await _ensureInitialized();
+    await _ensureUserInitialized();
 
-    await _supabase.deleteReport(id);
+    final String userId = _requiredUserId;
+
+    await _supabase.deleteReport(id: id, userId: userId);
     await _localStorage.removeCachedReport(id);
   }
 
   Future<void> clearReportsCache() async {
-    await _ensureInitialized();
+    await _ensureUserInitialized();
     await _localStorage.clearCachedReports();
   }
 
   Future<void> saveUserPreferences(UserPreferences preferences) async {
-    await _ensureInitialized();
+    await _ensureUserInitialized();
 
-    await _supabase.saveUserPreferences(preferences);
+    final String userId = _requiredUserId;
+
+    await _supabase.saveUserPreferences(
+      userId: userId,
+      preferences: preferences,
+    );
     await _localStorage.cacheUserPreferences(preferences);
   }
 
   Future<List<SafeRoute>> loadSafeRoutes() async {
-    await _ensureInitialized();
+    await _ensureUserInitialized();
+
+    final String userId = _requiredUserId;
 
     try {
-      final List<SafeRoute> routes = await _supabase.getSafeRoutes();
+      final List<SafeRoute> routes =
+          await _supabase.getSafeRoutes(userId: userId);
       await _localStorage.cacheSafeRoutes(routes);
       return routes;
     } catch (e) {
@@ -144,9 +175,25 @@ class StorageService {
   }
 
   Future<void> saveSafeRoutes(List<SafeRoute> routes) async {
-    await _ensureInitialized();
+    await _ensureUserInitialized();
 
-    await _supabase.saveSafeRoutes(routes);
+    final String userId = _requiredUserId;
+
+    await _supabase.saveSafeRoutes(userId: userId, routes: routes);
     await _localStorage.cacheSafeRoutes(routes);
+  }
+
+  Future<void> clearForSignOut() async {
+    _isUserInitialized = false;
+    _currentUserId = null;
+    await _localStorage.clearForSignOut();
+  }
+
+  String get _requiredUserId {
+    final String? userId = _currentUserId;
+    if (userId == null) {
+      throw StateError('No hay un usuario autenticado configurado.');
+    }
+    return userId;
   }
 }

--- a/lib/widgets/login_page.dart
+++ b/lib/widgets/login_page.dart
@@ -1,0 +1,239 @@
+import 'package:flutter/material.dart';
+
+import '../services/auth_service.dart';
+
+class LoginPage extends StatefulWidget {
+  const LoginPage({super.key});
+
+  @override
+  State<LoginPage> createState() => _LoginPageState();
+}
+
+class _LoginPageState extends State<LoginPage> {
+  final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
+  final AuthService _authService = AuthService.instance;
+
+  final TextEditingController _emailController = TextEditingController();
+  final TextEditingController _passwordController = TextEditingController();
+  final TextEditingController _confirmPasswordController =
+      TextEditingController();
+  final TextEditingController _fullNameController = TextEditingController();
+
+  bool _isLoginMode = true;
+  bool _isLoading = false;
+  String? _errorMessage;
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    _passwordController.dispose();
+    _confirmPasswordController.dispose();
+    _fullNameController.dispose();
+    super.dispose();
+  }
+
+  void _toggleMode() {
+    setState(() {
+      _isLoginMode = !_isLoginMode;
+      _errorMessage = null;
+    });
+  }
+
+  Future<void> _submit() async {
+    final FormState? formState = _formKey.currentState;
+    if (formState == null || !formState.validate()) {
+      return;
+    }
+
+    final String email = _emailController.text.trim();
+    final String password = _passwordController.text.trim();
+    final String fullName = _fullNameController.text.trim();
+
+    setState(() {
+      _isLoading = true;
+      _errorMessage = null;
+    });
+
+    try {
+      if (_isLoginMode) {
+        await _authService.login(email: email, password: password);
+      } else {
+        await _authService.register(
+          email: email,
+          password: password,
+          fullName: fullName.isEmpty ? null : fullName,
+        );
+      }
+    } on AuthenticationException catch (error) {
+      setState(() {
+        _errorMessage = error.message;
+      });
+    } catch (error) {
+      setState(() {
+        _errorMessage = 'Ocurrió un error inesperado. Inténtalo de nuevo.';
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final String title = _isLoginMode ? 'Inicia sesión' : 'Regístrate';
+
+    return Scaffold(
+      body: SafeArea(
+        child: Center(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.all(24),
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 420),
+              child: Card(
+                elevation: 2,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(16),
+                ),
+                child: Padding(
+                  padding: const EdgeInsets.all(24),
+                  child: Form(
+                    key: _formKey,
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: <Widget>[
+                        Text(
+                          title,
+                          style: theme.textTheme.headlineSmall?.copyWith(
+                            fontWeight: FontWeight.bold,
+                          ),
+                          textAlign: TextAlign.center,
+                        ),
+                        const SizedBox(height: 24),
+                        TextFormField(
+                          controller: _emailController,
+                          keyboardType: TextInputType.emailAddress,
+                          decoration: const InputDecoration(
+                            labelText: 'Correo electrónico',
+                            prefixIcon: Icon(Icons.email_outlined),
+                          ),
+                          validator: (String? value) {
+                            if (value == null || value.trim().isEmpty) {
+                              return 'Ingresa tu correo electrónico';
+                            }
+                            final String normalized = value.trim();
+                            if (!normalized.contains('@') ||
+                                !normalized.contains('.')) {
+                              return 'Ingresa un correo válido';
+                            }
+                            return null;
+                          },
+                        ),
+                        const SizedBox(height: 16),
+                        if (!_isLoginMode)
+                          Column(
+                            children: <Widget>[
+                              TextFormField(
+                                controller: _fullNameController,
+                                textCapitalization: TextCapitalization.words,
+                                decoration: const InputDecoration(
+                                  labelText: 'Nombre completo (opcional)',
+                                  prefixIcon: Icon(Icons.person_outline),
+                                ),
+                              ),
+                              const SizedBox(height: 16),
+                            ],
+                          ),
+                        TextFormField(
+                          controller: _passwordController,
+                          obscureText: true,
+                          decoration: const InputDecoration(
+                            labelText: 'Contraseña',
+                            prefixIcon: Icon(Icons.lock_outline),
+                          ),
+                          validator: (String? value) {
+                            if (value == null || value.isEmpty) {
+                              return 'Ingresa tu contraseña';
+                            }
+                            if (value.trim().length < 6) {
+                              return 'La contraseña debe tener al menos 6 caracteres';
+                            }
+                            return null;
+                          },
+                        ),
+                        if (!_isLoginMode)
+                          Padding(
+                            padding: const EdgeInsets.only(top: 16),
+                            child: TextFormField(
+                              controller: _confirmPasswordController,
+                              obscureText: true,
+                              decoration: const InputDecoration(
+                                labelText: 'Confirmar contraseña',
+                                prefixIcon: Icon(Icons.lock_reset),
+                              ),
+                              validator: (String? value) {
+                                if (_isLoginMode) {
+                                  return null;
+                                }
+                                if (value == null || value.isEmpty) {
+                                  return 'Confirma tu contraseña';
+                                }
+                                if (value.trim() !=
+                                    _passwordController.text.trim()) {
+                                  return 'Las contraseñas no coinciden';
+                                }
+                                return null;
+                              },
+                            ),
+                          ),
+                        const SizedBox(height: 24),
+                        if (_errorMessage != null)
+                          Padding(
+                            padding: const EdgeInsets.only(bottom: 16),
+                            child: Text(
+                              _errorMessage!,
+                              style: theme.textTheme.bodyMedium?.copyWith(
+                                color: theme.colorScheme.error,
+                              ),
+                              textAlign: TextAlign.center,
+                            ),
+                          ),
+                        FilledButton(
+                          onPressed: _isLoading ? null : _submit,
+                          child: _isLoading
+                              ? const SizedBox(
+                                  height: 20,
+                                  width: 20,
+                                  child: CircularProgressIndicator(
+                                    strokeWidth: 2,
+                                    valueColor:
+                                        AlwaysStoppedAnimation<Color>(Colors.white),
+                                  ),
+                                )
+                              : Text(_isLoginMode ? 'Ingresar' : 'Crear cuenta'),
+                        ),
+                        const SizedBox(height: 12),
+                        TextButton(
+                          onPressed: _isLoading ? null : _toggleMode,
+                          child: Text(
+                            _isLoginMode
+                                ? '¿No tienes cuenta? Regístrate'
+                                : '¿Ya tienes cuenta? Inicia sesión',
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,6 +43,7 @@ dependencies:
   http: ^1.1.0
   supabase_flutter: ^2.5.6
   flutter_dotenv: ^5.1.0
+  crypto: ^3.0.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add an AuthService backed by Supabase to manage hashed credentials and cached sessions
- implement login and registration UI plus an authentication gate around the main scaffold with logout support
- scope Supabase and local storage interactions by authenticated user identifiers

## Testing
- not run (Flutter SDK is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68df370a76f08330b3a399cdac967224