### PR TITLE
Update app_users policies to drop before create

### DIFF
--- a/supabase/migrations/20250310000000_add_app_users_and_user_scope.sql
+++ b/supabase/migrations/20250310000000_add_app_users_and_user_scope.sql
@@ -14,13 +14,15 @@ alter table app_users enable row level security;
 
 -- Políticas abiertas para poder registrar y validar usuarios desde el cliente.
 -- Ajusta estas políticas cuando integres un esquema de autenticación más estricto.
-create policy if not exists "anon_can_select_app_users"
+drop policy if exists "anon_can_select_app_users" on app_users;
+create policy "anon_can_select_app_users"
   on app_users
   for select
   to anon, authenticated
   using (true);
 
-create policy if not exists "anon_can_insert_app_users"
+drop policy if exists "anon_can_insert_app_users" on app_users;
+create policy "anon_can_insert_app_users"
   on app_users
   for insert
   to anon, authenticated


### PR DESCRIPTION
## Summary
- adjust app_users policy definitions to drop existing policies before recreating them

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df3e10f1a08330a40b3121cd9a64d4