### PR TITLE
Align storage service test fake with userId API

### DIFF
--- a/test/services/storage_service_test.dart
+++ b/test/services/storage_service_test.dart
@@ -21,27 +21,31 @@ class _FakeSupabaseService implements ReportsRemoteDataSource {
   }
 
   @override
-  Future<void> deleteReport(String id) async {
+  Future<void> deleteReport({
+    required String id,
+    required String userId,
+  }) async {
     _reports.removeWhere((Report report) => report.id == id);
   }
 
   @override
-  Future<List<Report>> getReports() async {
+  Future<List<Report>> getReports({required String userId}) async {
     return List<Report>.from(_reports);
   }
 
   @override
-  Future<List<SafeRoute>> getSafeRoutes() async {
+  Future<List<SafeRoute>> getSafeRoutes({required String userId}) async {
     return List<SafeRoute>.from(_routes);
   }
 
   @override
-  Future<UserPreferences?> getUserPreferences() async {
+  Future<UserPreferences?> getUserPreferences({required String userId}) async {
     return _preferences;
   }
 
   @override
   Future<Report> saveReport({
+    required String userId,
     required ReportType type,
     required String description,
     double? latitude,
@@ -60,12 +64,18 @@ class _FakeSupabaseService implements ReportsRemoteDataSource {
   }
 
   @override
-  Future<void> saveSafeRoutes(List<SafeRoute> routes) async {
+  Future<void> saveSafeRoutes({
+    required String userId,
+    required List<SafeRoute> routes,
+  }) async {
     _routes = List<SafeRoute>.from(routes);
   }
 
   @override
-  Future<void> saveUserPreferences(UserPreferences preferences) async {
+  Future<void> saveUserPreferences({
+    required String userId,
+    required UserPreferences preferences,
+  }) async {
     _preferences = preferences;
   }
 }


### PR DESCRIPTION
## Summary
- update the storage service test fake to accept the userId parameter across Supabase interactions
- keep the fake implementations no-op for the new argument while matching the remote data source contract

## Testing
- flutter test test/services/storage_service_test.dart *(fails: flutter not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68df4aa8510c8330aecede14fd25a457

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - No user-facing feature changes in this release.
- Tests
  - Updated test doubles to require user identification for all data operations, validating per-user scoping across reports, routes, and preferences without altering behavior.
- Chores
  - Aligned internal test data handling patterns for consistency and future scalability.
- Bug Fixes
  - None.
- Documentation
  - None.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->