### PR TITLE
Update storage service test setup for user initialization

### DIFF
--- a/test/services/storage_service_test.dart
+++ b/test/services/storage_service_test.dart
@@ -83,15 +83,18 @@ class _FakeSupabaseService implements ReportsRemoteDataSource {
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
+  const String testUserId = 'test-user';
   final LocalStorageService localStorage = LocalStorageService.instance;
 
   setUpAll(() async {
     SharedPreferences.setMockInitialValues(<String, Object?>{});
     await localStorage.initialize();
+    await localStorage.configureForUser(testUserId);
   });
 
   setUp(() async {
     SharedPreferences.setMockInitialValues(<String, Object?>{});
+    await localStorage.configureForUser(testUserId);
     await localStorage.clearCachedReports();
   });
 
@@ -118,7 +121,7 @@ void main() {
       supabase: supabase,
     );
 
-    await storage.initialize();
+    await storage.initializeForUser(testUserId);
     expect(storage.reports.length, 1);
     expect(storage.reports.first.id, remoteReport.id);
 
@@ -151,7 +154,7 @@ void main() {
       supabase: supabase,
     );
 
-    await storage.initialize();
+    await storage.initializeForUser(testUserId);
     expect(storage.reports.length, 2);
 
     supabase.setReports(<Report>[secondReport]);


### PR DESCRIPTION
## Summary
- ensure storage service tests initialize storage for a fixed test user
- configure local storage for the test user before clearing caches

## Testing
- flutter test test/services/storage_service_test.dart *(fails: `flutter` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68df4c6f30f483309c97214bc34c2b84

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for per-user storage configuration and initialization, enabling user-specific data isolation across sessions.
* **Tests**
  * Updated test setup to run in a per-user context to validate isolation and synchronization behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->