### PR TITLE
Fix lint warnings in weather data and remote service

### DIFF
--- a/lib/models/weather_data.dart
+++ b/lib/models/weather_data.dart
@@ -50,7 +50,7 @@ class WeatherData {
   String get windSpeedFormatted => '${windSpeed.toStringAsFixed(2)} m/s';
   String get humidityFormatted => '$humidity%';
   String get pressureFormatted => '$pressure hPa';
-  String get windDirectionFormatted => '${windDirection}°';
+  String get windDirectionFormatted => '$windDirection°';
   String get windGustFormatted => '${windGust.toStringAsFixed(2)} m/s';
   String get visibilityFormatted => '${(visibility / 1000).toStringAsFixed(1)} km';
   

--- a/lib/services/supabase_service.dart
+++ b/lib/services/supabase_service.dart
@@ -44,6 +44,7 @@ class SupabaseService implements ReportsRemoteDataSource {
     _isInitialized = true;
   }
 
+  @override
   Future<Report> saveReport({
     required String userId,
     required ReportType type,
@@ -79,6 +80,7 @@ class SupabaseService implements ReportsRemoteDataSource {
     );
   }
 
+  @override
   Future<List<Report>> getReports({required String userId}) async {
     final response = await client
         .from('reports')
@@ -98,6 +100,7 @@ class SupabaseService implements ReportsRemoteDataSource {
         .toList();
   }
 
+  @override
   Future<void> deleteReport({
     required String id,
     required String userId,
@@ -109,6 +112,7 @@ class SupabaseService implements ReportsRemoteDataSource {
         .eq('user_id', userId);
   }
 
+  @override
   Future<void> saveUserPreferences({
     required String userId,
     required UserPreferences preferences,
@@ -124,6 +128,7 @@ class SupabaseService implements ReportsRemoteDataSource {
         .upsert(data, onConflict: 'user_id');
   }
 
+  @override
   Future<UserPreferences?> getUserPreferences({required String userId}) async {
     final response = await client
         .from('user_preferences')
@@ -141,6 +146,7 @@ class SupabaseService implements ReportsRemoteDataSource {
     );
   }
 
+  @override
   Future<void> saveSafeRoutes({
     required String userId,
     required List<SafeRoute> routes,
@@ -161,6 +167,7 @@ class SupabaseService implements ReportsRemoteDataSource {
         .upsert(data, onConflict: 'user_id,name');
   }
 
+  @override
   Future<List<SafeRoute>> getSafeRoutes({required String userId}) async {
     final response = await client
         .from('safe_routes')

--- a/test/services/storage_service_test.dart
+++ b/test/services/storage_service_test.dart
@@ -87,13 +87,13 @@ void main() {
   final LocalStorageService localStorage = LocalStorageService.instance;
 
   setUpAll(() async {
-    SharedPreferences.setMockInitialValues(<String, Object?>{});
+    SharedPreferences.setMockInitialValues(<String, Object>{});
     await localStorage.initialize();
     await localStorage.configureForUser(testUserId);
   });
 
   setUp(() async {
-    SharedPreferences.setMockInitialValues(<String, Object?>{});
+    SharedPreferences.setMockInitialValues(<String, Object>{});
     await localStorage.configureForUser(testUserId);
     await localStorage.clearCachedReports();
   });


### PR DESCRIPTION
## Summary
- add missing @override annotations to Supabase service implementations
- clean up string interpolation lint in weather data formatting helper
- fix SharedPreferences mock setup to use non-nullable Object values

## Testing
- flutter test test/services/storage_service_test.dart *(fails: Flutter CLI is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68df2df333a08330adc52dfe48c0c2e1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized method overrides and code formatting to align with conventions; no functional changes.
* **Style**
  * Minor string interpolation cleanup with no impact on behavior or UI.
* **Tests**
  * Updated preferences mocking in tests to improve stability and consistency.
* **Chores**
  * Maintenance updates only; no user-facing changes in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->