### PR TITLE
Fix timeout exception construction in weather service

### DIFF
--- a/lib/services/weather_service.dart
+++ b/lib/services/weather_service.dart
@@ -95,7 +95,7 @@ class WeatherService {
 
       final response = await http.get(uri).timeout(
         const Duration(seconds: 10),
-        onTimeout: () => throw TimeoutException('Request timeout', 10 as Duration?),
+        onTimeout: () => throw TimeoutException('Request timeout', const Duration(seconds: 10)),
       );
 
       if (response.statusCode == 200) {


### PR DESCRIPTION
## Summary
- update the weather service timeout handler to throw a TimeoutException with a Duration instead of an invalid cast

## Testing
- flutter analyze *(fails: flutter command is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df51d003c88330a42cc670cdbe57c6