### PR TITLE
Guard login error updates behind mounted checks

### DIFF
--- a/lib/widgets/login_page.dart
+++ b/lib/widgets/login_page.dart
@@ -65,10 +65,12 @@ class _LoginPageState extends State<LoginPage> {
         );
       }
     } on AuthenticationException catch (error) {
+      if (!mounted) return;
       setState(() {
         _errorMessage = error.message;
       });
     } catch (error) {
+      if (!mounted) return;
       setState(() {
         _errorMessage = 'Ocurrió un error inesperado. Inténtalo de nuevo.';
       });


### PR DESCRIPTION
## Summary
- add mounted checks before updating the login error state when authentication fails
- keep the existing mounted guard around the loading reset in the finally block

## Testing
- flutter analyze *(fails: flutter CLI is not available in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df523c467c8330bae12ca299b94100