### PR TITLE
Remove redundant confirm password validator branch

### DIFF
--- a/lib/widgets/login_page.dart
+++ b/lib/widgets/login_page.dart
@@ -178,9 +178,6 @@ class _LoginPageState extends State<LoginPage> {
                                 prefixIcon: Icon(Icons.lock_reset),
                               ),
                               validator: (String? value) {
-                                if (_isLoginMode) {
-                                  return null;
-                                }
                                 if (value == null || value.isEmpty) {
                                   return 'Confirma tu contraseña';
                                 }


### PR DESCRIPTION
## Summary
- remove the unused login-mode branch from the confirm password validator
- keep only the null/empty and mismatch checks to avoid dead code warnings

## Testing
- flutter analyze *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68df52aebf8483308715059ee17ba939