### PR TITLE
Replace deprecated opacity usage

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -535,8 +535,8 @@ class _MapaPageState extends State<MapaPage> {
             circleId: CircleId(zone.id),
             center: zone.center,
             radius: zone.radius,
-            fillColor: Colors.red.withOpacity(0.2),
-            strokeColor: Colors.red.withOpacity(0.5),
+            fillColor: Colors.red.withAlpha(51),
+            strokeColor: Colors.red.withAlpha(128),
             strokeWidth: 2,
           ),
         )
@@ -1259,7 +1259,7 @@ class _ReportesPageState extends State<ReportesPage> {
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
       decoration: BoxDecoration(
-        color: colorScheme.surfaceVariant.withOpacity(0.6),
+        color: colorScheme.surfaceVariant.withAlpha((0.6 * 255).round()),
         borderRadius: BorderRadius.circular(12),
       ),
       child: Row(


### PR DESCRIPTION
## Summary
- replace deprecated withOpacity usage for danger zone colors with withAlpha equivalents
- update surface variant background color to use withAlpha rounding instead of opacity

## Testing
- flutter analyze *(fails: flutter command not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df53213d148330893437b9f66e3ab2