### PR TITLE
Refactor build directory providers

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -5,15 +5,11 @@ allprojects {
     }
 }
 
-val newBuildDir: Directory =
-    rootProject.layout.buildDirectory
-        .dir("../../build")
-        .get()
-rootProject.layout.buildDirectory.value(newBuildDir)
+val newBuildDir = rootProject.layout.buildDirectory.dir("../../build")
+rootProject.layout.buildDirectory.set(newBuildDir)
 
 subprojects {
-    val newSubprojectBuildDir: Directory = newBuildDir.dir(project.name)
-    project.layout.buildDirectory.value(newSubprojectBuildDir)
+    project.layout.buildDirectory.set(newBuildDir.map { it.dir(name) })
 }
 subprojects {
     project.evaluationDependsOn(":app")


### PR DESCRIPTION
## Summary
- refactor the Android build configuration to configure build directories using providers
- ensure each subproject maps its build directory through the provider-backed layout API

## Testing
- Not run (Gradle wrapper script not present in repository)

------
https://chatgpt.com/codex/tasks/task_e_68df577d5e0c8330b6f28a58cb9a1a58