### PR TITLE
Remove unreachable TypeError catch in AuthService

### DIFF
--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -57,8 +57,6 @@ class AuthService {
         _currentUserNotifier.value = AppUser.fromJson(decoded);
       } on FormatException {
         await _preferences?.remove(_sessionKey);
-      } on TypeError {
-        await _preferences?.remove(_sessionKey);
       }
     }
 


### PR DESCRIPTION
## Summary
- remove the unused TypeError branch from AuthService initialization error handling
- keep format exception handling to clear corrupt cached sessions

## Testing
- flutter analyze *(fails: flutter not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df5827b89c83309cb175d48ace15b3