### PR TITLE
Fix Postgrest error handling in auth service

### DIFF
--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -120,9 +120,7 @@ class AuthService {
       if (error.code == '23505') {
         throw AuthenticationException('El correo ya se encuentra registrado.');
       }
-      throw AuthenticationException(
-        error.message ?? 'Ocurrió un error al registrar la cuenta.',
-      );
+      throw AuthenticationException(error.message);
     }
   }
 


### PR DESCRIPTION
## Summary
- remove the redundant null-aware fallback when rethrowing PostgrestException messages during registration

## Testing
- flutter analyze *(fails: flutter not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68df5a741b10833085d1559dd18a00d4