### PR TITLE
Fix report type dropdown initialization

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1085,7 +1085,7 @@ class _ReportesPageState extends State<ReportesPage> {
           ),
           const SizedBox(height: 12),
           DropdownButtonFormField<ReportType>(
-            value: _selectedType,
+            initialValue: _selectedType,
             decoration: const InputDecoration(
               labelText: 'Tipo de reporte',
               border: OutlineInputBorder(),


### PR DESCRIPTION
## Summary
- replace the deprecated `value` parameter in the report form dropdown with `initialValue`
- keep the existing onChanged handler to continue updating the selected report type

## Testing
- flutter analyze *(fails: flutter is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df5c984440833089ac7772ef58d442