### PR TITLE
Capture messenger before saving preferences

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1110,6 +1110,8 @@ class _ReportesPageState extends State<ReportesPage> {
               });
 
               if (value != null) {
+                final ScaffoldMessengerState messenger =
+                    ScaffoldMessenger.of(context);
                 final UserPreferences currentPreferences =
                     _storageService.preferences.copyWith(
                   preferredReportTypeId: value.id,
@@ -1120,7 +1122,7 @@ class _ReportesPageState extends State<ReportesPage> {
                       if (!mounted) {
                         return;
                       }
-                      ScaffoldMessenger.of(context).showSnackBar(
+                      messenger.showSnackBar(
                         SnackBar(
                           content: Text(
                             'No se pudieron sincronizar las preferencias: $error',
@@ -1173,6 +1175,8 @@ class _ReportesPageState extends State<ReportesPage> {
                 _shareLocation = value;
               });
 
+              final ScaffoldMessengerState messenger =
+                  ScaffoldMessenger.of(context);
               final UserPreferences currentPreferences =
                   _storageService.preferences.copyWith(
                 shareLocation: value,
@@ -1183,7 +1187,7 @@ class _ReportesPageState extends State<ReportesPage> {
                     if (!mounted) {
                       return;
                     }
-                    ScaffoldMessenger.of(context).showSnackBar(
+                    messenger.showSnackBar(
                       SnackBar(
                         content: Text(
                           'No se pudieron sincronizar las preferencias: $error',


### PR DESCRIPTION
## Summary
- capture the scaffold messenger before saving user preferences from the dropdown and switch handlers
- reuse the captured messenger inside error handlers to avoid using the build context after async operations

## Testing
- flutter analyze *(fails: Flutter SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68df5d11056c8330965c231dcacfb2d9