### PR TITLE
Use surface container color for location indicator

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1263,7 +1263,8 @@ class _ReportesPageState extends State<ReportesPage> {
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
       decoration: BoxDecoration(
-        color: colorScheme.surfaceVariant.withAlpha((0.6 * 255).round()),
+        color: colorScheme.surfaceContainerHighest
+            .withAlpha((0.6 * 255).round()),
         borderRadius: BorderRadius.circular(12),
       ),
       child: Row(


### PR DESCRIPTION
## Summary
- update the location indicator container decoration to use `surfaceContainerHighest`

## Testing
- flutter analyze *(fails: Flutter SDK is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df5dab1b7083308244d74427584707