### PR TITLE
Update Gradle wrapper distribution URL

### DIFF
--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-all.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-8.12-all.zip


### PR DESCRIPTION
## Summary
- update the Android Gradle wrapper configuration to download Gradle 8.12

## Testing
- not run (gradlew script not present in repository)


------
https://chatgpt.com/codex/tasks/task_e_68df5f2921c88330b41728c0263b536f