### PR TITLE
Adjust Android build directory configuration

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -5,11 +5,11 @@ allprojects {
     }
 }
 
-val newBuildDir = rootProject.layout.buildDirectory.dir("../../build")
-rootProject.layout.buildDirectory.set(newBuildDir)
+val rootBuildDir = rootProject.layout.projectDirectory.dir("../build")
+rootProject.layout.buildDirectory.set(rootBuildDir)
 
 subprojects {
-    project.layout.buildDirectory.set(newBuildDir.map { it.dir(name) })
+    layout.buildDirectory.set(rootBuildDir.dir(name))
 }
 subprojects {
     project.evaluationDependsOn(":app")


### PR DESCRIPTION
## Summary
- derive the shared build directory from the root project's location to avoid circular evaluation
- point each subproject's build directory to a subfolder within the shared build directory

## Testing
- `./gradlew wrapper --gradle-version 8.12` *(fails: script not present in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68df62bcc5f48330a055822802de3871