### PR TITLE
Handle invalid cached reports entries

### DIFF
--- a/lib/services/local_storage_service.dart
+++ b/lib/services/local_storage_service.dart
@@ -62,12 +62,30 @@ class LocalStorageService {
       return;
     }
 
-    final List<Report> reports = box.values
-        .map((Map<String, dynamic> raw) => Report.fromJson(raw))
-        .toList(growable: false)
-      ..sort(
-        (Report a, Report b) => b.createdAt.compareTo(a.createdAt),
-      );
+    final List<Report> reports = <Report>[];
+
+    for (final dynamic key in box.keys) {
+      final Map<String, dynamic>? raw = box.get(key);
+      if (raw == null) {
+        continue;
+      }
+
+      try {
+        reports.add(Report.fromJson(raw));
+      } on FormatException catch (error, stackTrace) {
+        debugPrint('Error al cargar reporte "$key": $error');
+        debugPrint('$stackTrace');
+        await box.delete(key);
+      } on TypeError catch (error, stackTrace) {
+        debugPrint('Error al cargar reporte "$key": $error');
+        debugPrint('$stackTrace');
+        await box.delete(key);
+      }
+    }
+
+    reports.sort(
+      (Report a, Report b) => b.createdAt.compareTo(a.createdAt),
+    );
 
     _reportsNotifier.value = reports;
   }


### PR DESCRIPTION
## Summary
- guard `_loadStoredReports` against corrupted Hive entries and remove them while logging for debugging
- sort only the successfully parsed reports before updating the notifier
- add a storage service test that seeds an invalid cached report and ensures it is ignored

## Testing
- Not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e067d8794883309087181d2b963a42