### PR TITLE
Handle dynamic Hive report entries

### DIFF
--- a/lib/services/local_storage_service.dart
+++ b/lib/services/local_storage_service.dart
@@ -20,7 +20,7 @@ class LocalStorageService {
   bool _baseInitialized = false;
   String? _currentUserId;
   SharedPreferences? _preferences;
-  Box<Map<String, dynamic>>? _reportsBox;
+  Box<dynamic>? _reportsBox;
 
   final ValueNotifier<List<Report>> _reportsNotifier =
       ValueNotifier<List<Report>>(<Report>[]);
@@ -48,7 +48,7 @@ class LocalStorageService {
 
     _currentUserId = userId;
     await _reportsBox?.close();
-    _reportsBox = await Hive.openBox<Map<String, dynamic>>(
+    _reportsBox = await Hive.openBox<dynamic>(
       _reportsBoxNameForUser(userId),
     );
 
@@ -57,7 +57,7 @@ class LocalStorageService {
   }
 
   Future<void> _loadStoredReports() async {
-    final Box<Map<String, dynamic>>? box = _reportsBox;
+    final Box<dynamic>? box = _reportsBox;
     if (box == null) {
       return;
     }
@@ -65,13 +65,15 @@ class LocalStorageService {
     final List<Report> reports = <Report>[];
 
     for (final dynamic key in box.keys) {
-      final Map<String, dynamic>? raw = box.get(key);
+      final dynamic raw = box.get(key);
       if (raw == null) {
         continue;
       }
 
       try {
-        reports.add(Report.fromJson(raw));
+        final Map<String, dynamic> serialized =
+            Map<String, dynamic>.from(raw as Map<dynamic, dynamic>);
+        reports.add(Report.fromJson(serialized));
       } on FormatException catch (error, stackTrace) {
         debugPrint('Error al cargar reporte "$key": $error');
         debugPrint('$stackTrace');
@@ -125,7 +127,7 @@ class LocalStorageService {
 
   Future<void> cacheReports(List<Report> reports) async {
     await _ensureConfigured();
-    final Box<Map<String, dynamic>>? box = _reportsBox;
+    final Box<dynamic>? box = _reportsBox;
     if (box == null) {
       return;
     }
@@ -148,7 +150,7 @@ class LocalStorageService {
     DateTime? createdAt,
   }) async {
     await _ensureConfigured();
-    final Box<Map<String, dynamic>>? box = _reportsBox;
+    final Box<dynamic>? box = _reportsBox;
     if (box == null) {
       throw StateError('Reports box is not initialized');
     }
@@ -189,7 +191,7 @@ class LocalStorageService {
 
   Future<void> cacheReport(Report report) async {
     await _ensureConfigured();
-    final Box<Map<String, dynamic>>? box = _reportsBox;
+    final Box<dynamic>? box = _reportsBox;
     if (box == null) {
       return;
     }
@@ -200,7 +202,7 @@ class LocalStorageService {
 
   Future<void> removeCachedReport(String id) async {
     await _ensureConfigured();
-    final Box<Map<String, dynamic>>? box = _reportsBox;
+    final Box<dynamic>? box = _reportsBox;
     if (box == null) {
       return;
     }
@@ -211,7 +213,7 @@ class LocalStorageService {
 
   Future<void> clearCachedReports() async {
     await _ensureConfigured();
-    final Box<Map<String, dynamic>>? box = _reportsBox;
+    final Box<dynamic>? box = _reportsBox;
     if (box == null) {
       return;
     }

--- a/test/services/storage_service_test.dart
+++ b/test/services/storage_service_test.dart
@@ -168,8 +168,7 @@ void main() {
   });
 
   test('_loadStoredReports ignores invalid cached entries', () async {
-    final Box<Map<String, dynamic>> box =
-        Hive.box<Map<String, dynamic>>('reports_box_$testUserId');
+    final Box<dynamic> box = Hive.box<dynamic>('reports_box_$testUserId');
     await box.clear();
 
     final Report validReport = Report(
@@ -192,5 +191,26 @@ void main() {
     final List<Report> reports = localStorage.reports;
     expect(reports.length, 1);
     expect(reports.first.id, validReport.id);
+  });
+
+  test('_loadStoredReports converts dynamic map entries without throwing',
+      () async {
+    final Box<dynamic> box = Hive.box<dynamic>('reports_box_$testUserId');
+    await box.clear();
+
+    await box.put('dynamic-report', <dynamic, dynamic>{
+      'id': 'dynamic-report',
+      'typeId': ReportType.security.id,
+      'description': 'Dynamic map entry',
+      'createdAt': DateTime(2024, 6, 1).toIso8601String(),
+      'latitude': 12,
+      'longitude': -8,
+    });
+
+    await localStorage.configureForUser(testUserId);
+
+    final List<Report> reports = localStorage.reports;
+    expect(reports.length, 1);
+    expect(reports.first.id, 'dynamic-report');
   });
 }


### PR DESCRIPTION
## Summary
- relax the reports Hive box to accept dynamic map entries and convert them safely when loading
- keep report serialization intact while pruning corrupted cache values
- cover dynamic Hive entries with a new storage service test

## Testing
- flutter test test/services/storage_service_test.dart *(fails: flutter not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e06e29759c8330a7a9b7e48778060f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None
- Bug Fixes
  - Prevents crashes when loading malformed cached reports by gracefully skipping and cleaning invalid entries.
- Refactor
  - Switched cached report storage to a more flexible format for improved compatibility without changing user-facing behavior.
- Tests
  - Added coverage to ensure dynamic cached entries are converted safely.
  - Updated existing tests to reflect the new storage handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->